### PR TITLE
[DOC] README: hyperlink is shown in between badges #91

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,12 @@
 <h1 align="center">Smart Order Router</h1>
 <p align="center">
-    <a href="https://github.com/geniusyield/smart-order-router/actions?query=branch%3Amain">
-      <img src="https://img.shields.io/github/actions/workflow/status/geniusyield/smart-order-router/build.yml?style=flat-square&branch=main&label=Build" />
-    </a>
-    <a href="https://www.haskell.org/">
-      <img alt="GitHub top language" src="https://img.shields.io/github/languages/top/geniusyield/smart-order-router">
-    </a>
-    <a href="https://github.com/geniusyield/smart-order-router/commits/main">
-      <img src="https://img.shields.io/github/commit-activity/m/geniusyield/smart-order-router?style=flat-square&label=Commit%20Activity" />
-    </a>
-    <a href="https://github.com/geniusyield/smart-order-router/blob/main/LICENSE">
-      <img src="https://img.shields.io/github/license/geniusyield/smart-order-router?style=flat-square&label=Licence" />
-    </a>
-    <a href="./CONTRIBUTING.md">
-      <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square" />
-    </a>
-    <a href="https://twitter.com/GeniusyieldO">
-      <img src="https://img.shields.io/badge/-%40GeniusYieldO-F3F1EF?style=flat-square&logo=twitter&logoColor=1D9BF0" />
-    </a>
-    <a href="https://discord.gg/TNHf4fs626">
-      <img src="https://img.shields.io/badge/-Discord-414EEC?style=flat-square&logo=discord&logoColor=white" />
-    </a>
+    <a href="https://github.com/geniusyield/smart-order-router/actions?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/geniusyield/smart-order-router/build.yml?style=flat-square&branch=main&label=Build" /></a>
+    <a href="https://www.haskell.org/"><img alt="GitHub top language" src="https://img.shields.io/github/languages/top/geniusyield/smart-order-router"></a>
+    <a href="https://github.com/geniusyield/smart-order-router/commits/main"><img src="https://img.shields.io/github/commit-activity/m/geniusyield/smart-order-router?style=flat-square&label=Commit%20Activity" /></a>
+    <a href="https://github.com/geniusyield/smart-order-router/blob/main/LICENSE"><img src="https://img.shields.io/github/license/geniusyield/smart-order-router?style=flat-square&label=Licence" /></a>
+    <a href="./CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square" /></a>
+    <a href="https://twitter.com/GeniusyieldO"><img src="https://img.shields.io/badge/-%40GeniusYieldO-F3F1EF?style=flat-square&logo=twitter&logoColor=1D9BF0" /></a>
+    <a href="https://discord.gg/TNHf4fs626"><img src="https://img.shields.io/badge/-Discord-414EEC?style=flat-square&logo=discord&logoColor=white" /></a>
   </p>
 
 ## Table of contents


### PR DESCRIPTION
## Summary

Fixed the appearing "blue underscores" in between the badges in the README.

Before:

![image](https://github.com/geniusyield/smart-order-router/assets/2914096/37d2bc66-474a-48e2-8069-7f95055a6cd6)

After:

![image](https://github.com/geniusyield/smart-order-router/assets/2914096/6ccea676-87d7-460a-ad86-60e71742f320)


## Type of Change

Please mark the relevant option(s) for your pull request:

- Documentation update (adding or updating documentation related to the project)

## Checklist

- N / A

## Testing

- N / A

